### PR TITLE
add test for colinear_y

### DIFF
--- a/tasm-lib/src/recufier.rs
+++ b/tasm-lib/src/recufier.rs
@@ -1,3 +1,4 @@
+pub mod get_colinear_y;
 pub mod merkle_verify;
 pub mod proof_stream;
 mod xfe_ntt_autogen;


### PR DESCRIPTION
Also:
 - declare module in `recufier.rs`
 - reverse inputs to match stack order (even though this has no effect)
 - complete rust shadow
 - generate pseudorandom initial state
 - call test function supplied by testing framework